### PR TITLE
fix: account overflow and sidebar button

### DIFF
--- a/src/features/trip/edit/Tabs/TripTabs.tsx
+++ b/src/features/trip/edit/Tabs/TripTabs.tsx
@@ -30,7 +30,7 @@ function CustomTabPanel({
       hidden={value !== index}
       id={`trip-edit-tabpanel-${index}`}
       aria-labelledby={`trip-edit-tab-${index}`}
-      style={{ height: '90vh' }}
+      style={{ minHeight: '90vh' }}
     >
       {children}
     </div>

--- a/src/features/ui/layout/AccountLayout/AccountLayout.tsx
+++ b/src/features/ui/layout/AccountLayout/AccountLayout.tsx
@@ -96,7 +96,7 @@ export default function AccountLayout() {
             onClick={handleDrawerToggle}
             sx={{
               borderRadius: 1,
-              position: 'absolute',
+              position: 'fixed',
               top: 27,
               left: `calc(${
                 isOpen ? DESKTOP_DRAWER_WIDTH : DESKTOP_MINIMIZED_DRAWER_WIDTH

--- a/src/features/ui/layout/AccountLayout/AccountLayout.tsx
+++ b/src/features/ui/layout/AccountLayout/AccountLayout.tsx
@@ -79,8 +79,7 @@ export default function AccountLayout() {
       sx={{
         display: 'flex',
         bgcolor: 'grey.100',
-        minHeight: { md: '100vh' },
-        height: { xs: '100vh', md: 'auto' },
+        minHeight: '100vh',
         maxHeight: { xs: '-webkit-fill-available', md: 'auto' },
       }}
     >

--- a/src/features/ui/layout/AccountLayout/AccountLayout.tsx
+++ b/src/features/ui/layout/AccountLayout/AccountLayout.tsx
@@ -80,7 +80,6 @@ export default function AccountLayout() {
         display: 'flex',
         bgcolor: 'grey.100',
         minHeight: '100vh',
-        maxHeight: { xs: '-webkit-fill-available', md: 'auto' },
       }}
     >
       {/* Desktop Drawer */}


### PR DESCRIPTION
- Fixed overflow on trip details page
- Fixed account sidebar close/open button, to make sure it doesn't scroll together with the page